### PR TITLE
fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This action supports `.dmg`, `.pkg` file and `.app` folder.
 
 ```yaml
 - name: Notarize product
-  uses: love-action/xcode-notarizer@v1
+  uses: love-actions/xcode-notarizer@v1
   with:
     product-path: ./dist/my_app.app
     key-content: ${{ secrets.API_KEY }}


### PR DESCRIPTION
This fixes a typo in the second example in the readme. If copied, the action will fail.